### PR TITLE
Fix issue while getting the code from an error

### DIFF
--- a/webfleet_connect/webfleet_connect_error.py
+++ b/webfleet_connect/webfleet_connect_error.py
@@ -17,7 +17,7 @@ class WebfleetConnectError(Exception):
       f'Check {self._api_docs_url()} for more details.\n\n'
   
   def code(self):
-    return int(self._code)
+    return self._code
   
   def url(self):
     return self._url


### PR DESCRIPTION
Hi there,

I have the following PR to address an issue I found while capturing a Webfleet error. The code method is trying to convert the errorCode from Webfleet response into a integer but some errors are alphanumeric so we should return the value as string 
