### PR TITLE
Added an urllib encoding to the raw url before the get request to the…

### DIFF
--- a/webfleet_connect/connection.py
+++ b/webfleet_connect/connection.py
@@ -1,4 +1,5 @@
 import requests
+import urllib.parse
 from .webfleet_connect_error import WebfleetConnectError
 from .webfleet_connect_response import WebfleetConnectResponse
 from .format_handlers.csv_error_parser import CsvErrorParser
@@ -10,7 +11,8 @@ class Connection:
     self._error_parser = self._build_error_parser(session)
 
   def exec(self, url):
-    response = requests.get(url)
+    encoded_url = urllib.parse.quote_plus(url, safe=":/&=?")
+    response = requests.get(encoded_url)
     is_json = self._session.has_json()
     if self._is_error_found(response):
       raise WebfleetConnectError(response, url, is_json)


### PR DESCRIPTION
… server


During usage of this library I encountered the problem that the library doesn't  encode the URL before submitting the GET request to the server. 
In particular I stumbled into issues where a hashtag character was plainly placed within the URL and I got an error message from the server because of it. By first encoding the URL with the urllib quote_plus function, the hashtag got encoded properly and the library works as expected.